### PR TITLE
Adds PCG XSH RR pseudo random number generator

### DIFF
--- a/src/PCG_XSH_RR.vhd
+++ b/src/PCG_XSH_RR.vhd
@@ -50,15 +50,14 @@ begin
     if rising_edge(clk) then
         if rst = '1' then
             state <= unsigned(seed);
-            rand <= (others => '0');
             valid <= '0';
             perm_state <= LCG;
-            rotation := 0;
         else
             case (perm_state) is
             when LCG =>
                 oldstate <= state;
                 tmp <= LCG_MULT * state;
+                valid <= '0';
 
                 perm_state <= XORSHIFT_STATE;
             when XORSHIFT_STATE =>
@@ -72,7 +71,7 @@ begin
                 perm_state <= ROTATION_STATE;
 
             when ROTATION_STATE =>
-                rand <= std_logic_vector(xorshift ror rotation);
+                rand <= std_logic_vector(rotate_right(xorshift, rotation));
                 valid <= '1';
 
                 -- finish LCG update (2 cycles since tmp was assigned)

--- a/src/PCG_XSH_RR.vhd
+++ b/src/PCG_XSH_RR.vhd
@@ -69,7 +69,7 @@ begin
             when XORSHIFT_STATE =>
                 -- compute 32-bit xorshift
                 -- xorshift := (state ^ (state >> 18)) >> 27
-                xorshift := state(59 downto 28) xor state(49 downto 18);
+                xorshift := state(58 downto 27) xor (13x"0000" & state(63 downto 45));
 
                 rotation := to_integer(state(63 downto 59));
                 valid <= '0';

--- a/src/PCG_XSH_RR.vhd
+++ b/src/PCG_XSH_RR.vhd
@@ -1,0 +1,89 @@
+----
+-- Original author: Blake Johnson
+-- Copyright 2017, Raytheon BBN Technologies
+--
+-- A pseudorandom number generator of the PCG family (M.E. O'Neill 2017).
+-- The specific version we choose is the "PGC-XSH-RR" generator which combines
+-- a simple LCG with a permutation function composed of an xorshift and a bit
+-- rotation. The implementation is pipelined to allow it to run at high clock
+-- speeds.
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+library unisim;
+use unisim.vcomponents.all;
+
+entity PCG_XSH_RR is
+    port (
+        rst   : in std_logic;
+        clk   : in std_logic;
+        seed  : in std_logic_vector(63 downto 0);
+        rand  : out std_logic_vector(31 downto 0);
+        valid : out std_logic
+    );
+end entity;
+
+architecture arch of PCG_XSH_RR is
+
+signal state : unsigned(63 downto 0);
+
+type permutation_state_t is (XORSHIFT_STATE, ROTATION_STATE);
+signal perm_state : permutation_state_t := XORSHIFT_STATE;
+
+begin
+
+LCG : process(clk)
+-- multiplicative constant comes from PCG basic implementation
+-- https://github.com/imneme/pcg-c-basic
+constant LCG_MULT : unsigned(63 downto 0) := 64d"6364136223846793005";
+constant LCG_ADD  : unsigned(63 downto 0) := 64d"2531011"; -- can be any odd number
+variable tmp      : unsigned(127 downto 0);
+
+begin
+    if rising_edge(clk) then
+        if rst = '1' then
+            state <= unsigned(seed);
+        else
+            if perm_state = ROTATION_STATE then
+                tmp := LCG_MULT * state;
+                state <= tmp(63 downto 0) + LCG_ADD;
+            end if;
+        end if;
+    end if;
+end process;
+
+permutation_function : process(clk)
+variable xorshift : unsigned(31 downto 0);
+variable rotation : natural range 0 to 31 := 0;
+begin
+    if rising_edge(clk) then
+        if rst = '1' then
+            rand <= (others => '0');
+            valid <= '0';
+            perm_state <= XORSHIFT_STATE;
+            rotation := 0;
+        else
+            case (perm_state) is
+            when XORSHIFT_STATE =>
+                -- compute 32-bit xorshift
+                -- xorshift := (state ^ (state >> 18)) >> 27
+                xorshift := state(59 downto 28) xor state(49 downto 18);
+
+                rotation := to_integer(state(63 downto 59));
+                valid <= '0';
+
+                perm_state <= ROTATION_STATE;
+
+            when ROTATION_STATE =>
+                rand <= std_logic_vector(xorshift ror rotation);
+                valid <= '1';
+
+                perm_state <= XORSHIFT_STATE;
+            end case;
+        end if;
+    end if;
+end process;
+
+end architecture;

--- a/src/PCG_XSH_RR.vhd
+++ b/src/PCG_XSH_RR.vhd
@@ -28,50 +28,45 @@ end entity;
 architecture arch of PCG_XSH_RR is
 
 signal state : unsigned(63 downto 0);
+signal oldstate : unsigned(63 downto 0);
 
-type permutation_state_t is (XORSHIFT_STATE, ROTATION_STATE);
+type permutation_state_t is (LCG, XORSHIFT_STATE, ROTATION_STATE);
 signal perm_state : permutation_state_t := XORSHIFT_STATE;
+
+-- process signals
+signal tmp        : unsigned(127 downto 0);
+signal xorshift   : unsigned(31 downto 0);
 
 begin
 
-LCG : process(clk)
+
+pcg : process(clk)
 -- multiplicative constant comes from PCG basic implementation
 -- https://github.com/imneme/pcg-c-basic
 constant LCG_MULT : unsigned(63 downto 0) := 64d"6364136223846793005";
 constant LCG_ADD  : unsigned(63 downto 0) := 64d"2531011"; -- can be any odd number
-variable tmp      : unsigned(127 downto 0);
-
-begin
-    if rising_edge(clk) then
-        if rst = '1' then
-            state <= unsigned(seed);
-        else
-            if perm_state = ROTATION_STATE then
-                tmp := LCG_MULT * state;
-                state <= tmp(63 downto 0) + LCG_ADD;
-            end if;
-        end if;
-    end if;
-end process;
-
-permutation_function : process(clk)
-variable xorshift : unsigned(31 downto 0);
 variable rotation : natural range 0 to 31 := 0;
 begin
     if rising_edge(clk) then
         if rst = '1' then
+            state <= unsigned(seed);
             rand <= (others => '0');
             valid <= '0';
-            perm_state <= XORSHIFT_STATE;
+            perm_state <= LCG;
             rotation := 0;
         else
             case (perm_state) is
+            when LCG =>
+                oldstate <= state;
+                tmp <= LCG_MULT * state;
+
+                perm_state <= XORSHIFT_STATE;
             when XORSHIFT_STATE =>
                 -- compute 32-bit xorshift
                 -- xorshift := (state ^ (state >> 18)) >> 27
-                xorshift := state(58 downto 27) xor (13x"0000" & state(63 downto 45));
+                xorshift <= oldstate(58 downto 27) xor (13x"0000" & oldstate(63 downto 45));
 
-                rotation := to_integer(state(63 downto 59));
+                rotation := to_integer(oldstate(63 downto 59));
                 valid <= '0';
 
                 perm_state <= ROTATION_STATE;
@@ -80,7 +75,10 @@ begin
                 rand <= std_logic_vector(xorshift ror rotation);
                 valid <= '1';
 
-                perm_state <= XORSHIFT_STATE;
+                -- finish LCG update (2 cycles since tmp was assigned)
+                state <= tmp(63 downto 0) + LCG_ADD;
+
+                perm_state <= LCG;
             end case;
         end if;
     end if;

--- a/test/PCG.jl
+++ b/test/PCG.jl
@@ -1,0 +1,23 @@
+module PCG
+
+import Base: rand
+export PCGenerator
+
+type PCGenerator
+    state::UInt64
+    offset::UInt64
+end
+
+PCGenerator(state=0) = PCGenerator(state, 2531011)
+
+function rand(g::PCGenerator)
+    oldstate = g.state
+    # LCG step to advance internal state
+    g.state = 6364136223846793005 * g.state + g.offset
+    # calculate output function (XSH RR)
+    xorshifted = (((oldstate >>> 18) $ oldstate) >>> 27) % UInt32
+    rot = (oldstate >>> 59) % UInt32
+    return (xorshifted >>> rot) | (xorshifted << ((-rot) & 31))
+end
+
+end

--- a/test/PCG_XSH_RR_tb.vhd
+++ b/test/PCG_XSH_RR_tb.vhd
@@ -26,15 +26,20 @@ architecture bench of PCG_XSH_RR_tb is
 
     type rand_array is array(0 to 7) of std_logic_vector(31 downto 0);
     signal rand_outs : rand_array := (others => (others => '0'));
+    -- expected outs computed using PCG.jl:
+    -- julia> include("PCG.jl")
+    -- julia> using PCG
+    -- julia> g = PCG(1234)
+    -- julia> [rand(g) for _ in 1:8]
     signal expected_outs : rand_array := (
-        0 => 32d"1234",
-        1 => 32d"1234",
-        2 => 32d"1234",
-        3 => 32d"1234",
-        4 => 32d"1234",
-        5 => 32d"1234",
-        6 => 32d"1234",
-        7 => 32d"1234"
+        0 => x"00000000",
+        1 => x"cb267ac2",
+        2 => x"035401a4",
+        3 => x"3db8c0ea",
+        4 => x"45b49a87",
+        5 => x"42f4a7aa",
+        6 => x"d6016e1c",
+        7 => x"3922cc67"
     );
 
 

--- a/test/PCG_XSH_RR_tb.vhd
+++ b/test/PCG_XSH_RR_tb.vhd
@@ -86,11 +86,7 @@ begin
     checking : process
     begin
 
-        wait until rising_edge(clk) and test_bench_state = TEST_RAND;
-        -- PCG latency
-        for ct in 1 to (rand_outs'high * LATENCY) loop
-            wait until rising_edge(clk);
-        end loop;
+        wait until rising_edge(clk) and test_bench_state = FINISHED;
 
         for ct in rand_outs'range loop
             -- compare against a known result

--- a/test/PCG_XSH_RR_tb.vhd
+++ b/test/PCG_XSH_RR_tb.vhd
@@ -18,7 +18,7 @@ architecture bench of PCG_XSH_RR_tb is
     constant clock_period    : time := 4.0 ns;
     signal stop_the_clock    : boolean := false;
     signal checking_finished : boolean := false;
-    constant LATENCY : natural := 10;
+    constant LATENCY : natural := 3;
 
     signal seed     : std_logic_vector(63 downto 0) := std_logic_vector(to_unsigned(1234, 64));
     signal rand_out : std_logic_vector(31 downto 0);
@@ -88,7 +88,7 @@ begin
 
         wait until rising_edge(clk) and test_bench_state = TEST_RAND;
         -- PCG latency
-        for ct in 1 to (rand_outs'high + LATENCY) loop
+        for ct in 1 to (rand_outs'high * LATENCY) loop
             wait until rising_edge(clk);
         end loop;
 

--- a/test/PCG_XSH_RR_tb.vhd
+++ b/test/PCG_XSH_RR_tb.vhd
@@ -1,0 +1,102 @@
+-- test bench for the PCG pseudorandom number generator
+--
+-- Original author: Blake Johnson
+-- Copyright 2017 Raytheon BBN Technologies
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity PCG_XSH_RR_tb is
+end;
+
+architecture bench of PCG_XSH_RR_tb is
+
+    signal clk               : std_logic := '0';
+    signal rst               : std_logic := '0';
+
+    constant clock_period    : time := 4.0 ns;
+    signal stop_the_clock    : boolean := false;
+    signal checking_finished : boolean := false;
+    constant LATENCY : natural := 10;
+
+    signal seed     : std_logic_vector(63 downto 0) := std_logic_vector(to_unsigned(1234, 64));
+    signal rand_out : std_logic_vector(31 downto 0);
+    signal valid    : std_logic;
+
+    type rand_array is array(0 to 7) of std_logic_vector(31 downto 0);
+    signal rand_outs : rand_array := (others => (others => '0'));
+    signal expected_outs : rand_array := (
+        0 => 32d"1234",
+        1 => 32d"1234",
+        2 => 32d"1234",
+        3 => 32d"1234",
+        4 => 32d"1234",
+        5 => 32d"1234",
+        6 => 32d"1234",
+        7 => 32d"1234"
+    );
+
+
+    type TestBenchState_t is (RESET, TEST_RAND, FINISHED);
+    signal test_bench_state : TestBenchState_t;
+
+begin
+
+    uut: entity work.PCG_XSH_RR
+    port map (
+        clk => clk,
+        rst => rst,
+        seed => seed,
+        rand => rand_out,
+        valid => valid
+    );
+
+    clk <= not clk after clock_period / 2 when not stop_the_clock;
+
+    stimulus : process
+    begin
+
+        ---------------------------
+        test_bench_state <= RESET;
+        rst <= '1';
+        wait for 20 ns;
+        wait until rising_edge(clk);
+        rst <= '0';
+
+        test_bench_state <= TEST_RAND;
+
+        for ct in rand_outs'range loop
+            wait until rising_edge(valid);
+            rand_outs(ct) <= rand_out;
+        end loop;
+
+        test_bench_state <= FINISHED;
+        wait for 100 ns;
+        stop_the_clock <= true;
+        wait;
+
+    end process;
+
+    checking : process
+    begin
+
+        wait until rising_edge(clk) and test_bench_state = TEST_RAND;
+        -- PCG latency
+        for ct in 1 to (rand_outs'high + LATENCY) loop
+            wait until rising_edge(clk);
+        end loop;
+
+        for ct in rand_outs'range loop
+            -- compare against a known result
+            assert rand_outs(ct) = expected_outs(ct) report "PCG output error: expected " &
+                integer'image( to_integer( unsigned(expected_outs(ct) ) )) & " but got " &
+                integer'image( to_integer( unsigned(rand_outs(ct) ) ));
+        end loop;
+
+        report "FINISHED PCG output checking";
+        checking_finished <= true;
+
+    end process;
+
+end;


### PR DESCRIPTION
Computes a new pseudorandom number on every other clock cycle. The user seeds the PNG by providing the seed value at the input and pumping `rst`.

Future enhancements:
- [ ] Make the output width or range generic (non-power of 2 ranges are more tricky)
- [ ] Provide a gating mechanism, such as pushing outputs into a FIFO, so that the user has a well-defined way of getting the Nth output of the PNG.